### PR TITLE
Feature/backlog send data to db

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import { Provider } from "react-redux";
 import store from "./redux/store";
 import GlobalMenu from "./components/layout/GlobalMenu";
@@ -7,6 +7,42 @@ import Home from "./pages/home/Home";
 import Details from "./pages/details/Details";
 import { Container, CssBaseline } from "@mui/material";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
+import Onb001Details from "./pages/details/Onb001Details";
+import Onb002Details from "./pages/details/Onb002Details";
+import Onb003Details from "./pages/details/Onb003Details";
+import Onb004Details from "./pages/details/Onb004Details";
+import Onb005Details from "./pages/details/Onb005Details";
+import Dive006Details from "./pages/details/Dive006Details";
+import Dive007Details from "./pages/details/Dive007Details";
+import Dive008Details from "./pages/details/Dive008Details";
+import Dive009Details from "./pages/details/Dive009Details";
+import Dive010Details from "./pages/details/Dive010Details";
+import Dive011Details from "./pages/details/Dive011Details";
+import Lead012Details from "./pages/details/Lead012Details";
+import Lead013Details from "./pages/details/Lead013Details";
+import Lead014Details from "./pages/details/Lead014Details";
+import Lead015Details from "./pages/details/Lead015Details";
+import Lead016Details from "./pages/details/Lead016Details";
+import Cult017Details from "./pages/details/Cult017Details";
+import Cult018Details from "./pages/details/Cult018Details";
+import Cult019Details from "./pages/details/Cult019Details";
+import Cult020Details from "./pages/details/Cult020Details";
+import Cult021Details from "./pages/details/Cult021Details";
+import Skil022Details from "./pages/details/Skil022Details";
+import Skil023Details from "./pages/details/Skil023Details";
+import Skil024Details from "./pages/details/Skil024Details";
+import Recr025Details from "./pages/details/Recr025Details";
+import Welb026Details from "./pages/details/Welb026Details";
+import Welb027Details from "./pages/details/Welb027Details";
+import Welb028Details from "./pages/details/Welb028Details";
+import Rewd029Details from "./pages/details/Rewd029Details";
+import Rewd030Details from "./pages/details/Rewd030Details";
+import Succ031Details from "./pages/details/Succ031Details";
+import Succ032Details from "./pages/details/Succ032Details";
+import Succ033Details from "./pages/details/Succ033Details";
+import Compl034Details from "./pages/details/Comp034Details";
+import Compl035Details from "./pages/details/Comp035Details";
+import Compl036Details from "./pages/details/Comp036Details";
 
 // デフォルトカラーの設定
 const theme = createTheme({
@@ -33,6 +69,65 @@ const theme = createTheme({
   },
 });
 
+// クエリパラメータ：IDに対するコンポーネントマッピング
+const componentMap: Record<string, React.FC> = {
+  "Onboarding_KnowledgeSupport_001": Onb001Details,
+  "Onboarding_SkillGapAssessment_002": Onb002Details,
+  "Onboarding_NetworkBuilding_003": Onb003Details,
+  "Onboarding_ProgressManagement_004": Onb004Details,
+  "Onboarding_CultureIntegration_005": Onb005Details,
+  "Diversity_GenderEquality_006": Dive006Details,
+  "Diversity_CulturalInclusion_007": Dive007Details,
+  "Diversity_DisabilitySupport_008": Dive008Details,
+  "Diversity_LGBTQInclusion_009": Dive009Details,
+  "Diversity_AgeInclusion_010": Dive010Details,
+  "Diversity_RegionalDiversity_011": Dive011Details,
+  "Leadership_Identification_012": Lead012Details,
+  "Leadership_TrainingDesign_013": Lead013Details,
+  "Leadership_PracticalSupport_014": Lead014Details,
+  "Leadership_ProgressMonitoring_015": Lead015Details,
+  "Leadership_CrossOrganizationalExchange_016": Lead016Details,
+  "Culture_EngagementScore_017": Cult017Details,
+  "Culture_FeedbackAnalysis_018": Cult018Details,
+  "Culture_WorkshopSupport_019": Cult019Details,
+  "Culture_DI_Promotion_020": Cult020Details,
+  "Culture_CultureChangeMonitoring_021": Cult021Details,
+  "Skill_Reskilling_022": Skil022Details,
+  "Skill_CareerDevelopment_023": Skil023Details,
+  "Skill_PerformanceManagement_024": Skil024Details,
+  "Recruitment_ReferralSupport_025": Recr025Details,
+  "Wellbeing_HealthSupport_026": Welb026Details,
+  "Wellbeing_CafeteriaPlan_027": Welb027Details,
+  "Wellbeing_HybridWork_028": Welb028Details,
+  "Reward_NonMonetary_029": Rewd029Details,
+  "Reward_PerformanceBased_030": Rewd030Details,
+  "Succession_LeaderIdentification_031": Succ031Details,
+  "Succession_DevelopmentProgram_032": Succ032Details,
+  "Succession_ProgressMonitoring_033": Succ033Details,
+  "Compliance_LaborLaw_034": Compl034Details,
+  "Compliance_DataProtection_035": Compl035Details,
+  "Compliance_InternationalRegulation_036": Compl036Details,  
+};
+
+/**
+ * クエリパラメータから遷移先コンポーネントを判定するコンポーネント
+*/
+const DynamicDetailComponent: React.FC = () => {
+  // 現在のURL取得
+  const location = useLocation();
+  // クエリパラメータの解析
+  const searchParams = new URLSearchParams(location.search);
+  const detailId = searchParams.get("elementId");
+  // IDに対応するコンポーネントを取得
+  const SelectedComponent = detailId && componentMap[detailId] 
+    ? componentMap[detailId] 
+    : () => <p>該当する詳細が見つかりません。</p>;
+  return <SelectedComponent />;
+};
+
+/**
+ * アプリケーションのメインコンポーネント
+*/
 const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
@@ -44,7 +139,7 @@ const App: React.FC = () => {
           <Container>
             <Routes>
               <Route path="/" element={<Home />} />
-              <Route path="/details" element={<Details />} />
+              <Route path="/details" element={<DynamicDetailComponent />} />
             </Routes>
           </Container>
         </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,9 +40,9 @@ import Rewd030Details from "./pages/details/Rewd030Details";
 import Succ031Details from "./pages/details/Succ031Details";
 import Succ032Details from "./pages/details/Succ032Details";
 import Succ033Details from "./pages/details/Succ033Details";
-import Compl034Details from "./pages/details/Comp034Details";
-import Compl035Details from "./pages/details/Comp035Details";
-import Compl036Details from "./pages/details/Comp036Details";
+import Comp034Details from "./pages/details/Comp034Details";
+import Comp035Details from "./pages/details/Comp035Details";
+import Comp036Details from "./pages/details/Comp036Details";
 
 // デフォルトカラーの設定
 const theme = createTheme({
@@ -104,9 +104,9 @@ const componentMap: Record<string, React.FC> = {
   "Succession_LeaderIdentification_031": Succ031Details,
   "Succession_DevelopmentProgram_032": Succ032Details,
   "Succession_ProgressMonitoring_033": Succ033Details,
-  "Compliance_LaborLaw_034": Compl034Details,
-  "Compliance_DataProtection_035": Compl035Details,
-  "Compliance_InternationalRegulation_036": Compl036Details,  
+  "Compliance_LaborLaw_034": Comp034Details,
+  "Compliance_DataProtection_035": Comp035Details,
+  "Compliance_InternationalRegulation_036": Comp036Details,  
 };
 
 /**

--- a/src/components/layout/AgentCategoryLayout.tsx
+++ b/src/components/layout/AgentCategoryLayout.tsx
@@ -4,6 +4,7 @@ import AgentCategoryContainer from "../organisms/AgentCategoryContainer";
 
 // エージェント項目の型定義
 interface AgentItem {
+  elementId: string;
   title: string;
   description: string;
   image: string;
@@ -38,7 +39,7 @@ const AgentCategoryLayout: React.FC<Props> = ({ categories, title }) => {
         {Object.entries(categories).map(([categoryName, agents]) => (
           <AgentCategoryContainer
             key={categoryName}
-            title={categoryName}
+            categoryName={categoryName}
             agents={agents}
           />
         ))}

--- a/src/components/molecules/AgentCard.tsx
+++ b/src/components/molecules/AgentCard.tsx
@@ -46,7 +46,7 @@ const AgentCard: React.FC<Props> = ({
         myleName: myleName,
       })
     );
-    navigate(path);
+    navigate(`${path}?elementId=${elementId}`);
   };
 
   return (

--- a/src/components/molecules/AgentCard.tsx
+++ b/src/components/molecules/AgentCard.tsx
@@ -8,6 +8,7 @@ import { RootState } from "../../redux/store";
 import { selectMyle } from "../../pages/home/homeSlice";
 
 interface Props {
+  id: number;
   title: string;
   description: string;
   image: string;
@@ -15,6 +16,7 @@ interface Props {
 }
 
 const AgentCard: React.FC<Props> = ({
+  id,
   title,
   description,
   image,
@@ -27,7 +29,7 @@ const AgentCard: React.FC<Props> = ({
   const handleCardClick = (
     navigate: any,
     path: string,
-    id: string,
+    id: any,
     title: string
   ) => {
     dispatch(
@@ -48,7 +50,7 @@ const AgentCard: React.FC<Props> = ({
         display: "flex",
         flexDirection: "column",
       }}
-      onClick={() => handleCardClick(navigate, navigateTo, title, title)}
+      onClick={() => handleCardClick(navigate, navigateTo, id, title)}
     >
       <CardContent
         sx={{

--- a/src/components/molecules/AgentCard.tsx
+++ b/src/components/molecules/AgentCard.tsx
@@ -8,16 +8,20 @@ import { RootState } from "../../redux/store";
 import { selectMyle } from "../../pages/home/homeSlice";
 
 interface Props {
-  id: number;
-  title: string;
-  description: string;
-  image: string;
+  elementId: string; // 操作データを識別する一意な文字列
+  id: number; // カテゴリ内の各カードを識別するためのID
+  categoryName: string; // カテゴリの名前
+  myleName: string; // Myleの名前
+  description: string; // Myleの説明
+  image: string; // Myleのイメージ画像
   navigateTo: string; // 遷移先ページのパス
 }
 
 const AgentCard: React.FC<Props> = ({
+  elementId,
   id,
-  title,
+  categoryName,
+  myleName,
   description,
   image,
   navigateTo,
@@ -27,15 +31,19 @@ const AgentCard: React.FC<Props> = ({
 
   // onclick関数はここに
   const handleCardClick = (
+    elementId: any,
     navigate: any,
     path: string,
     id: any,
-    title: string
+    categoryName: string,
+    myleName: string
   ) => {
     dispatch(
       selectMyle({
+        elementId: elementId,
         id: id,
-        title: title,
+        categoryName: categoryName,
+        myleName: myleName,
       })
     );
     navigate(path);
@@ -50,7 +58,7 @@ const AgentCard: React.FC<Props> = ({
         display: "flex",
         flexDirection: "column",
       }}
-      onClick={() => handleCardClick(navigate, navigateTo, id, title)}
+      onClick={() => handleCardClick(elementId, navigate, navigateTo, id, categoryName, myleName)}
     >
       <CardContent
         sx={{
@@ -62,12 +70,12 @@ const AgentCard: React.FC<Props> = ({
       >
         {/* Title atom - 固定高さ */}
         <Box sx={{ height: 60, mb: 1 }}>
-          <Typography text={title} variant="h6" />
+          <Typography text={categoryName} variant="h6" />
         </Box>
 
         {/* Image atom - 固定高さ */}
         <Box sx={{ height: 140, mb: 2, position: "relative" }}>
-          <Image src={image} alt={title} height="100%" width="100%" />
+          <Image src={image} alt={categoryName} height="100%" width="100%" />
         </Box>
 
         {/* Description atom - 残りのスペースを使用 */}

--- a/src/components/molecules/TemplateMessage.tsx
+++ b/src/components/molecules/TemplateMessage.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Grid, Typography, Paper } from "@mui/material";
+
+interface MessageTemplate {
+  messageText: string;
+  icon: React.ReactNode;
+  type: string;
+}
+
+interface TemplateSelectorProps {
+  templates: MessageTemplate[];
+  selectedTemplate: string | null;
+  onTemplateClick: (templateText: string) => void;
+}
+
+const TemplateSelector: React.FC<TemplateSelectorProps> = ({
+  templates,
+  selectedTemplate,
+  onTemplateClick,
+}) => {
+  return (
+    <Grid container spacing={2}>
+      {templates.map((template) => (
+        <Grid item xs={4} key={template.type}>
+          <Paper
+            sx={{
+              padding: 2,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              alignItems: "center",
+              cursor: "pointer",
+              border:
+                selectedTemplate === template.type
+                  ? "2px solid #007bff"
+                  : "none",
+              "&:hover": { backgroundColor: "#F1CF24" },
+            }}
+            onClick={() => onTemplateClick(template.messageText)}
+          >
+            {template.icon}
+            <Typography variant="body2" sx={{ marginTop: 1 }}>
+              {template.messageText}
+            </Typography>
+          </Paper>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
+
+export default TemplateSelector;

--- a/src/components/organisms/AgentCategoryContainer.tsx
+++ b/src/components/organisms/AgentCategoryContainer.tsx
@@ -32,7 +32,7 @@ const AgentCategoryContainer: React.FC<Props> = ({ title, agents }) => {
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
         {agents.map((agent, index) => (
           <AgentCard
-            key={index}
+            id={index + 1}
             title={agent.title}
             description={agent.description}
             image={agent.image}

--- a/src/components/organisms/AgentCategoryContainer.tsx
+++ b/src/components/organisms/AgentCategoryContainer.tsx
@@ -4,6 +4,7 @@ import AgentCard from "../molecules/AgentCard";
 
 // エージェント項目の型定義
 interface AgentItem {
+  elementId: string;
   title: string;
   description: string;
   image: string;
@@ -12,7 +13,7 @@ interface AgentItem {
 
 // コンポーネントのプロパティ型定義
 interface Props {
-  title: string;
+  categoryName: string;
   agents: AgentItem[];
 }
 
@@ -20,20 +21,22 @@ interface Props {
  * エージェントカテゴリーコンテナコンポーネント
  * 特定のカテゴリーに属するエージェントカードを表示する
  */
-const AgentCategoryContainer: React.FC<Props> = ({ title, agents }) => {
+const AgentCategoryContainer: React.FC<Props> = ({ categoryName, agents }) => {
   return (
     <Box sx={{ marginBottom: 4 }}>
       {/* カテゴリータイトル */}
       <Typography variant="h5" sx={{ backgroundColor: '#E3823D', color: 'white' }}>
-        {title}
+        {categoryName}
       </Typography>
       
       {/* エージェントカードのコンテナ - フレックスボックスでラップして表示 */}
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
         {agents.map((agent, index) => (
           <AgentCard
+            elementId={agent.elementId}
             id={index + 1}
-            title={agent.title}
+            categoryName={categoryName}
+            myleName={agent.title}
             description={agent.description}
             image={agent.image}
             navigateTo={`/${agent.detailPage}`} // detailPageは必須項目

--- a/src/components/organisms/chatContainer.tsx
+++ b/src/components/organisms/chatContainer.tsx
@@ -22,9 +22,10 @@ import {
   Info as InfoIcon,
 } from "@mui/icons-material";
 
+// TODO コンポーネント分割、関数型に修正
 const ChatApp = () => {
   const dispatch = useDispatch();
-  const messages = useSelector((state: RootState) => state.details.messages);
+  const messages = useSelector((state: RootState) => state.details.chatMessages);
   const [input, setInput] = useState("");
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
 
@@ -36,7 +37,7 @@ const ChatApp = () => {
           id: Date.now().toString(),
           sender: "me",
           userName: "User",
-          text: input,
+          chatText: input,
         })
       );
       setInput("");
@@ -88,7 +89,7 @@ const ChatApp = () => {
                     textAlign: message.sender === "me" ? "right" : "left",
                   }}
                 >
-                  <Box>{message.text}</Box>
+                  <Box>{message.chatText}</Box>
                 </Box>
               </ListItem>
             ))}

--- a/src/components/organisms/chatContainer.tsx
+++ b/src/components/organisms/chatContainer.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useEffect} from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../redux/store";
-import { sendMessage, sendMessageByHelpButton } from "../../pages/details/detailsSlice";
+import { sendMessage, sendMessageByHelpButton, setCurrentScreen } from "../../pages/details/detailsSlice";
 import { TextField, Button, Container, Paper, List, ListItem, Box, Grid, Typography } from "@mui/material";
 import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
 import TemplateSelector from "../molecules/TemplateMessage";
+import { useLocation } from "react-router-dom";
 
 interface MessageTemplate {
   messageText: string;
@@ -20,9 +21,19 @@ const ChatApp: React.FC<TemplateSelectorProps> = ({
   messageTemplates: messageTemplates,
 }) => {
   const dispatch = useDispatch();
+  //  ReduxからcurrentScreenを取得
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const elementId = searchParams.get("elementId"); // URLからelementIdを取得
+  
   const messages = useSelector((state: RootState) => state.details.chatMessages);
   const [input, setInput] = useState("");
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
+
+  // ✅ currentScreenをReduxに保存
+  useEffect(() => {
+    dispatch(setCurrentScreen(elementId || null));
+  }, [elementId, dispatch]);
 
   // メッセージを送信
   const handleSendMessage = () => {

--- a/src/components/organisms/chatContainer.tsx
+++ b/src/components/organisms/chatContainer.tsx
@@ -1,29 +1,24 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../redux/store";
-import {
-  sendMessage,
-  sendMessageByHelpButton,
-} from "../../pages/details/detailsSlice";
-import {
-  TextField,
-  Button,
-  Container,
-  Paper,
-  List,
-  ListItem,
-  Box,
-  Grid,
-  Typography,
-} from "@mui/material";
-import {
-  Send as SendIcon,
-  Help as HelpIcon,
-  Info as InfoIcon,
-} from "@mui/icons-material";
+import { sendMessage, sendMessageByHelpButton } from "../../pages/details/detailsSlice";
+import { TextField, Button, Container, Paper, List, ListItem, Box, Grid, Typography } from "@mui/material";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+import TemplateSelector from "../molecules/TemplateMessage";
 
-// TODO コンポーネント分割、関数型に修正
-const ChatApp = () => {
+interface MessageTemplate {
+  messageText: string;
+  icon: React.ReactNode;
+  type: string;
+}
+
+interface TemplateSelectorProps {
+  messageTemplates: MessageTemplate[];
+}
+
+const ChatApp: React.FC<TemplateSelectorProps> = ({
+  messageTemplates: messageTemplates,
+}) => {
   const dispatch = useDispatch();
   const messages = useSelector((state: RootState) => state.details.chatMessages);
   const [input, setInput] = useState("");
@@ -96,90 +91,12 @@ const ChatApp = () => {
           </List>
         </Box>
 
-        {/* テンプレート選択 */}
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            marginBottom: 2,
-          }}
-        >
-          <Grid container spacing={2}>
-            <Grid item xs={4}>
-              <Paper
-                sx={{
-                  padding: 2,
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  cursor: "pointer",
-                  border:
-                    selectedTemplate === "message"
-                      ? "2px solid #007bff"
-                      : "none",
-                  "&:hover": { backgroundColor: "#F1CF24" },
-                }}
-                onClick={() =>
-                  handleTemplateClick("AさんとBさんにイベント告知をして")
-                }
-              >
-                <SendIcon fontSize="large" />
-                <Typography variant="body2" sx={{ marginTop: 1 }}>
-                  AさんとBさんにイベント告知をして
-                </Typography>
-              </Paper>
-            </Grid>
-            <Grid item xs={4}>
-              <Paper
-                sx={{
-                  padding: 2,
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  cursor: "pointer",
-                  border:
-                    selectedTemplate === "help" ? "2px solid #007bff" : "none",
-                  "&:hover": { backgroundColor: "#F1CF24" },
-                }}
-                onClick={() =>
-                  handleTemplateClick(
-                    "女性向け産休説明会を女性従業員に告知して"
-                  )
-                }
-              >
-                <HelpIcon fontSize="large" />
-                <Typography variant="body2" sx={{ marginTop: 1 }}>
-                  女性向け産休説明会を女性従業員に告知して
-                </Typography>
-              </Paper>
-            </Grid>
-            <Grid item xs={4}>
-              <Paper
-                sx={{
-                  padding: 2,
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  cursor: "pointer",
-                  border:
-                    selectedTemplate === "info" ? "2px solid #007bff" : "none",
-                  "&:hover": { backgroundColor: "#F1CF24" },
-                }}
-                onClick={() =>
-                  handleTemplateClick("管理職に管理職向けイベントを告知して")
-                }
-              >
-                <InfoIcon fontSize="large" />
-                <Typography variant="body2" sx={{ marginTop: 1 }}>
-                  管理職に管理職向けイベントを告知して
-                </Typography>
-              </Paper>
-            </Grid>
-          </Grid>
-        </Box>
+        {/* 入力テンプレート */}
+        <TemplateSelector
+          templates={messageTemplates}
+          selectedTemplate={selectedTemplate}
+          onTemplateClick={handleTemplateClick}
+        />
 
         {/* メッセージ入力フォーム */}
         <Box sx={{ display: "flex", marginTop: 2 }}>

--- a/src/components/organisms/processContainer.tsx
+++ b/src/components/organisms/processContainer.tsx
@@ -73,7 +73,7 @@ const ProcessContainer = () => {
                   )
                 }
               >
-                <Typography variant="body1">{msg.text}</Typography>
+                <Typography variant="body1">{msg.processText}</Typography>
               </StepLabel>
             </Step>
           ))}

--- a/src/constants/agent_organization.json
+++ b/src/constants/agent_organization.json
@@ -1,240 +1,276 @@
 {
-    "categories": {
-        "オンボーディング支援": [
-            {
-                "title": "業務知識・手続き支援エージェント",
-                "description": "新入社員への業務知識の提供と必要な手続きをガイドします。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "スキルギャップ診断と育成エージェント",
-                "description": "新入社員のスキルギャップを診断し、個別の育成計画を提案します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "社内ネットワーク構築支援エージェント",
-                "description": "新入社員が社内の人脈を効率的に構築できるよう導きます。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "オンボーディング進捗管理エージェント",
-                "description": "新入社員の適応状況を追跡し、必要に応じて追加支援を提案します。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "文化・価値観の浸透支援エージェント",
-                "description": "企業文化や価値観を新入社員に効果的に伝えるサポートを行います。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "ダイバーシティ推進": [
-            {
-                "title": "ジェンダーダイバーシティエージェント",
-                "description": "職場におけるジェンダー平等を促進し、バランスのとれた環境づくりを実現します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "文化・国籍の多様性エージェント",
-                "description": "異なる文化や国籍を持つ従業員の統合と相互理解を促進します。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "障がい者雇用と支援エージェント",
-                "description": "障がいを持つ従業員のワークライフを向上させるための包括的な支援を提供します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "LGBTQ+の包摂性向上エージェント",
-                "description": "LGBTQ+コミュニティに対する理解を深め、インクルーシブな職場環境を構築します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "年齢多様性（世代間融合）エージェント",
-                "description": "異なる世代間のコミュニケーションと協力を促進し、知識継承を円滑にします。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "地域の多様性（地方創生）エージェント",
-                "description": "地域特性を活かした多様な働き方と地方創生の取り組みを支援します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "リーダーシップ育成": [
-            {
-                "title": "リーダーの特定エージェント",
-                "description": "組織内の潜在的リーダーを発掘し、その素質を正確に評価します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "リーダーシップトレーニング設計エージェント",
-                "description": "個々のリーダーのニーズに合わせたカスタマイズ型トレーニングプログラムを設計します。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "現場型リーダーシップ開発支援エージェント",
-                "description": "実務を通じたリーダーシップスキル向上のための実践的支援を行います。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "リーダー候補の進捗モニタリングエージェント",
-                "description": "リーダー育成プログラムの効果を測定し、継続的な成長をサポートします。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "組織間リーダー交流支援エージェント",
-                "description": "部門を超えたリーダー間の交流と知見共有を促進します。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "組織風土改善": [
-            {
-                "title": "エンゲージメントスコアの可視化エージェント",
-                "description": "従業員エンゲージメントを数値化し、リアルタイムで組織状態を把握します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "社員フィードバック収集と分析エージェント",
-                "description": "匿名フィードバックを収集・分析し、組織課題の早期発見を支援します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "ワークショップ・トレーニング支援エージェント",
-                "description": "組織風土改善のためのワークショップ設計と実施をサポートします。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "多様性と包括性（D&I）推進支援エージェント",
-                "description": "組織内の多様性と包括性を高めるための施策立案と実行を支援します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "文化変革プログラムのモニタリングエージェント",
-                "description": "組織文化改革の進捗状況を追跡し、効果測定を行います。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "スキル・能力開発（全般）": [
-            {
-                "title": "リスキリングエージェント",
-                "description": "従業員の新しいスキル獲得を支援し、キャリア転換をサポートします。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "キャリア開発支援エージェント",
-                "description": "個々の従業員のキャリアパス設計と実現を支援します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "パフォーマンス管理エージェント",
-                "description": "業績評価と能力開発を連動させ、継続的な成長を促進します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "採用関連": [
-            {
-                "title": "リファラル採用支援エージェント",
-                "description": "従業員の人脈を活用した採用活動を効率化し、質の高い人材獲得を実現します。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "福利厚生（Well-being支援）": [
-            {
-                "title": "健康支援プログラムエージェント",
-                "description": "従業員の心身の健康をサポートし、予防医療や健康増進活動を推進します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "カフェテリアプラン管理エージェント",
-                "description": "多様な福利厚生メニューから従業員が自由に選択できる制度を管理します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "ハイブリッドワーク支援エージェント",
-                "description": "リモートとオフィスのバランスを取りながら効率的に働ける環境づくりを支援します。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "リワード（報酬・インセンティブ）": [
-            {
-                "title": "非金銭的報酬（称賛・認識）エージェント",
-                "description": "社内表彰制度や感謝の表現を通じて従業員のモチベーションを高めます。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "パフォーマンス連動型報酬エージェント",
-                "description": "成果に基づく公平な報酬システムを設計し、運用をサポートします。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "サクセッションプランニング": [
-            {
-                "title": "リーダー候補の特定エージェント",
-                "description": "将来の経営幹部や重要ポジションを担う人材を見極め、早期に育成計画を立てます。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "育成プログラムの設計エージェント",
-                "description": "次世代リーダーの育成に必要なスキルと経験を体系的に提供するプログラムを設計します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "進捗モニタリングと評価エージェント",
-                "description": "後継者育成計画の進捗を定期的に確認し、必要に応じて調整を行います。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            }
-        ],
-        "HRコンプライアンス": [
-            {
-                "title": "労働法対応エージェント",
-                "description": "変化する労働法規制に適応し、法令順守の徹底をサポートします。",
-                "image": "images/knowledgeSupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "データ保護とプライバシーエージェント",
-                "description": "従業員データの適切な管理と保護を実現し、プライバシーリスクを低減します。",
-                "image": "images/1on1SupportMyle.png",
-                "detailPage": "details"
-            },
-            {
-                "title": "多国籍法規制対応エージェント",
-                "description": "グローバル人事における各国の法的要件に対応し、国際的なコンプライアンスを確保します。",
-                "image": "images/eventCommunicattionSupportMyle.png",
-                "detailPage": "details"
-            }
-        ]
-    }
+  "categories": {
+    "オンボーディング支援": [
+      {
+        "elementId": "Onboarding_KnowledgeSupport_001",
+        "title": "業務知識・手続き支援エージェント",
+        "description": "新入社員への業務知識の提供と必要な手続きをガイドします。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Onboarding_SkillGapAssessment_002",
+        "title": "スキルギャップ診断と育成エージェント",
+        "description": "新入社員のスキルギャップを診断し、個別の育成計画を提案します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Onboarding_NetworkBuilding_003",
+        "title": "社内ネットワーク構築支援エージェント",
+        "description": "新入社員が社内の人脈を効率的に構築できるよう導きます。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Onboarding_ProgressManagement_004",
+        "title": "オンボーディング進捗管理エージェント",
+        "description": "新入社員の適応状況を追跡し、必要に応じて追加支援を提案します。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Onboarding_CultureIntegration_005",
+        "title": "文化・価値観の浸透支援エージェント",
+        "description": "企業文化や価値観を新入社員に効果的に伝えるサポートを行います。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "ダイバーシティ推進": [
+      {
+        "elementId": "Diversity_GenderEquality_006",
+        "title": "ジェンダーダイバーシティエージェント",
+        "description": "職場におけるジェンダー平等を促進し、バランスのとれた環境づくりを実現します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Diversity_CulturalInclusion_007",
+        "title": "文化・国籍の多様性エージェント",
+        "description": "異なる文化や国籍を持つ従業員の統合と相互理解を促進します。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Diversity_DisabilitySupport_008",
+        "title": "障がい者雇用と支援エージェント",
+        "description": "障がいを持つ従業員のワークライフを向上させるための包括的な支援を提供します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Diversity_LGBTQInclusion_009",
+        "title": "LGBTQ+の包摂性向上エージェント",
+        "description": "LGBTQ+コミュニティに対する理解を深め、インクルーシブな職場環境を構築します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Diversity_AgeInclusion_010",
+        "title": "年齢多様性（世代間融合）エージェント",
+        "description": "異なる世代間のコミュニケーションと協力を促進し、知識継承を円滑にします。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Diversity_RegionalDiversity_011",
+        "title": "地域の多様性（地方創生）エージェント",
+        "description": "地域特性を活かした多様な働き方と地方創生の取り組みを支援します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "リーダーシップ育成": [
+      {
+        "elementId": "Leadership_Identification_012",
+        "title": "リーダーの特定エージェント",
+        "description": "組織内の潜在的リーダーを発掘し、その素質を正確に評価します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Leadership_TrainingDesign_013",
+        "title": "リーダーシップトレーニング設計エージェント",
+        "description": "個々のリーダーのニーズに合わせたカスタマイズ型トレーニングプログラムを設計します。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Leadership_PracticalSupport_014",
+        "title": "現場型リーダーシップ開発支援エージェント",
+        "description": "実務を通じたリーダーシップスキル向上のための実践的支援を行います。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Leadership_ProgressMonitoring_015",
+        "title": "リーダー候補の進捗モニタリングエージェント",
+        "description": "リーダー育成プログラムの効果を測定し、継続的な成長をサポートします。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Leadership_CrossOrganizationalExchange_016",
+        "title": "組織間リーダー交流支援エージェント",
+        "description": "部門を超えたリーダー間の交流と知見共有を促進します。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "組織風土改善": [
+      {
+        "elementId": "Culture_EngagementScore_017",
+        "title": "エンゲージメントスコアの可視化エージェント",
+        "description": "従業員エンゲージメントを数値化し、リアルタイムで組織状態を把握します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Culture_FeedbackAnalysis_018",
+        "title": "社員フィードバック収集と分析エージェント",
+        "description": "匿名フィードバックを収集・分析し、組織課題の早期発見を支援します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Culture_WorkshopSupport_019",
+        "title": "ワークショップ・トレーニング支援エージェント",
+        "description": "組織風土改善のためのワークショップ設計と実施をサポートします。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Culture_DI_Promotion_020",
+        "title": "多様性と包括性（D&I）推進支援エージェント",
+        "description": "組織内の多様性と包括性を高めるための施策立案と実行を支援します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Culture_CultureChangeMonitoring_021",
+        "title": "文化変革プログラムのモニタリングエージェント",
+        "description": "組織文化改革の進捗状況を追跡し、効果測定を行います。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "スキル・能力開発（全般）": [
+      {
+        "elementId": "Skill_Reskilling_022",
+        "title": "リスキリングエージェント",
+        "description": "従業員の新しいスキル獲得を支援し、キャリア転換をサポートします。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Skill_CareerDevelopment_023",
+        "title": "キャリア開発支援エージェント",
+        "description": "個々の従業員のキャリアパス設計と実現を支援します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Skill_PerformanceManagement_024",
+        "title": "パフォーマンス管理エージェント",
+        "description": "業績評価と能力開発を連動させ、継続的な成長を促進します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "採用関連": [
+      {
+        "elementId": "Recruitment_ReferralSupport_025",
+        "title": "リファラル採用支援エージェント",
+        "description": "従業員の人脈を活用した採用活動を効率化し、質の高い人材獲得を実現します。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "福利厚生（Well-being支援）": [
+      {
+        "elementId": "Wellbeing_HealthSupport_026",
+        "title": "健康支援プログラムエージェント",
+        "description": "従業員の心身の健康をサポートし、予防医療や健康増進活動を推進します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Wellbeing_CafeteriaPlan_027",
+        "title": "カフェテリアプラン管理エージェント",
+        "description": "多様な福利厚生メニューから従業員が自由に選択できる制度を管理します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Wellbeing_HybridWork_028",
+        "title": "ハイブリッドワーク支援エージェント",
+        "description": "リモートとオフィスのバランスを取りながら効率的に働ける環境づくりを支援します。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "リワード（報酬・インセンティブ）": [
+      {
+        "elementId": "Reward_NonMonetary_029",
+        "title": "非金銭的報酬（称賛・認識）エージェント",
+        "description": "社内表彰制度や感謝の表現を通じて従業員のモチベーションを高めます。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Reward_PerformanceBased_030",
+        "title": "パフォーマンス連動型報酬エージェント",
+        "description": "成果に基づく公平な報酬システムを設計し、運用をサポートします。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "サクセッションプランニング": [
+      {
+        "elementId": "Succession_LeaderIdentification_031",
+        "title": "リーダー候補の特定エージェント",
+        "description": "将来の経営幹部や重要ポジションを担う人材を見極め、早期に育成計画を立てます。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Succession_DevelopmentProgram_032",
+        "title": "育成プログラムの設計エージェント",
+        "description": "次世代リーダーの育成に必要なスキルと経験を体系的に提供するプログラムを設計します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Succession_ProgressMonitoring_033",
+        "title": "進捗モニタリングと評価エージェント",
+        "description": "後継者育成計画の進捗を定期的に確認し、必要に応じて調整を行います。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      }
+    ],
+    "HRコンプライアンス": [
+      {
+        "elementId": "Compliance_LaborLaw_034",
+        "title": "労働法対応エージェント",
+        "description": "変化する労働法規制に適応し、法令順守の徹底をサポートします。",
+        "image": "images/knowledgeSupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Compliance_DataProtection_035",
+        "title": "データ保護とプライバシーエージェント",
+        "description": "従業員データの適切な管理と保護を実現し、プライバシーリスクを低減します。",
+        "image": "images/1on1SupportMyle.png",
+        "detailPage": "details"
+      },
+      {
+        "elementId": "Compliance_InternationalRegulation_036",
+        "title": "多国籍法規制対応エージェント",
+        "description": "グローバル人事における各国の法的要件に対応し、国際的なコンプライアンスを確保します。",
+        "image": "images/eventCommunicattionSupportMyle.png",
+        "detailPage": "details"
+      }
+    ]
+  }
 }

--- a/src/constants/detail_messages.json
+++ b/src/constants/detail_messages.json
@@ -1,40 +1,1371 @@
 {
-  "messages": {
-    "pattern1": {
-      "process_messages": [
-        "イベント情報の取得",
-        "Aさんの従業員情報の取得",
-        "Bさんの従業員情報の取得",
-        "Aさん向けの告知文を作成",
-        "Bさん向けの告知文を作成",
-        "Aさんに告知文章を送信",
-        "Bさんに告知文章を送信"
-      ],
-      "send_trigger_message": "AさんとBさんにイベント告知をして",
-      "myle_response": "AさんとBさんにイベントを告知しました",
-      "output_url": "/images/eventNoticeResult.png"
+  "screens": {
+    "Onboarding_KnowledgeSupport_001": {
+      "pattern1": {
+        "process_messages": [
+          "オンボーディング1：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング1：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "オンボーディング1：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング1：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "オンボーディング1：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング1：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
     },
-    "pattern2": {
-      "process_messages": [
-        "女性従業員のデータを取得",
-        "女性向け産休説明会のイベント情報を取得",
-        "一人一人の従業員に対しての告知文を作成",
-        "女性従業員に告知文章を送信"
-      ],
-      "send_trigger_message": "女性向け産休説明会を女性従業員に告知して",
-      "myle_response": "女性従業員に産休説明会を告知しました。",
-      "output_url": "/images/eventNoticeResult2.png"
+    "Onboarding_SkillGapAssessment_002": {
+      "pattern1": {
+        "process_messages": [
+          "オンボーディング2：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング2：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "オンボーディング2：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング2：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "オンボーディング2：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング2：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
     },
-    "pattern3": {
-      "process_messages": [
-        "管理職情報の取得",
-        "管理職向けイベント情報の取得",
-        "管理職向けの告知文を作成",
-        "管理職に告知文章を送信"
-      ],
-      "send_trigger_message": "管理職に管理職向けイベントを告知して",
-      "myle_response": "管理職向けイベントを告知しました。",
-      "output_url": "/images/eventNoticeResult3.png"
+    "Onboarding_NetworkBuilding_003": {
+      "pattern1": {
+        "process_messages": [
+          "オンボーディング3：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング3：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "オンボーディング3：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング3：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "オンボーディング3：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング3：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Onboarding_ProgressManagement_004": {
+      "pattern1": {
+        "process_messages": [
+          "オンボーディング4：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング4：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "オンボーディング4：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング4：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "オンボーディング4：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング4：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Onboarding_CultureIntegration_005": {
+      "pattern1": {
+        "process_messages": [
+          "オンボーディング5：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング5：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "オンボーディング5：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング5：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "オンボーディング5：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "オンボーディング5：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Diversity_GenderEquality_006": {
+      "pattern1": {
+        "process_messages": [
+          "ダイバーシティ6：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ6：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "ダイバーシティ6：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ6：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "ダイバーシティ6：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ6：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Diversity_CulturalInclusion_007": {
+      "pattern1": {
+        "process_messages": [
+          "ダイバーシティ7：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ7：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "ダイバーシティ7：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ7：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "ダイバーシティ7：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ7：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Diversity_DisabilitySupport_008": {
+      "pattern1": {
+        "process_messages": [
+          "ダイバーシティ8：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ8：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "ダイバーシティ8：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ8：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "ダイバーシティ8：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ8：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Diversity_LGBTQInclusion_009": {
+      "pattern1": {
+        "process_messages": [
+          "ダイバーシティ9：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ9：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "ダイバーシティ9：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ9：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "ダイバーシティ9：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ9：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Diversity_AgeInclusion_010": {
+      "pattern1": {
+        "process_messages": [
+          "ダイバーシティ10：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ10：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "ダイバーシティ10：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ10：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "ダイバーシティ10：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ10：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Diversity_RegionalDiversity_011": {
+      "pattern1": {
+        "process_messages": [
+          "ダイバーシティ11：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ11：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "ダイバーシティ11：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ11：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "ダイバーシティ11：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "ダイバーシティ11：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Leadership_Identification_012": {
+      "pattern1": {
+        "process_messages": [
+          "リーダーシップ12：Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ12：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リーダーシップ12：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ12：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リーダーシップ12：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ12：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Leadership_TrainingDesign_013": {
+      "pattern1": {
+        "process_messages": [
+          "リーダーシップ13：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ13：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リーダーシップ13：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ13：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リーダーシップ13：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ13：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Leadership_PracticalSupport_014": {
+      "pattern1": {
+        "process_messages": [
+          "リーダーシップ14：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ14：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リーダーシップ14：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ14：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リーダーシップ14：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ14：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Leadership_ProgressMonitoring_015": {
+      "pattern1": {
+        "process_messages": [
+          "リーダーシップ15：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ15：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リーダーシップ15：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ15：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リーダーシップ15：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ15：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Leadership_CrossOrganizationalExchange_016": {
+      "pattern1": {
+        "process_messages": [
+          "リーダーシップ16：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ16：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リーダーシップ16：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ16：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リーダーシップ16：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リーダーシップ16：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Culture_EngagementScore_017": {
+      "pattern1": {
+        "process_messages": [
+          "組織風土17：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土17：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "組織風土17：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土17：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "組織風土17：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土17：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Culture_FeedbackAnalysis_018": {
+      "pattern1": {
+        "process_messages": [
+          "組織風土18：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土18：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "組織風土18：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土18：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "組織風土18：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土18：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Culture_WorkshopSupport_019": {
+      "pattern1": {
+        "process_messages": [
+          "組織風土19：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土19：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "組織風土19：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土19：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "組織風土19：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土19：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Culture_DI_Promotion_020": {
+      "pattern1": {
+        "process_messages": [
+          "組織風土20：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土20：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "組織風土20：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土20：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "組織風土20：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土20：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Culture_CultureChangeMonitoring_021": {
+      "pattern1": {
+        "process_messages": [
+          "組織風土21：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土21：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "組織風土21：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土21：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "組織風土21：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "組織風土21：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Skill_Reskilling_022": {
+      "pattern1": {
+        "process_messages": [
+          "スキル能力22：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力22：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "スキル能力22：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力22：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "スキル能力22：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力22：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Skill_CareerDevelopment_023": {
+      "pattern1": {
+        "process_messages": [
+          "スキル能力23：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力23：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "スキル能力23：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力23：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "スキル能力23：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力23：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Skill_PerformanceManagement_024": {
+      "pattern1": {
+        "process_messages": [
+          "スキル能力24：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力24：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "スキル能力24：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力24：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "スキル能力24：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "スキル能力24：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Recruitment_ReferralSupport_025": {
+      "pattern1": {
+        "process_messages": [
+          "採用関連25：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "採用関連25：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "採用関連25：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "採用関連25：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "採用関連25：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "採用関連25：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Wellbeing_HealthSupport_026": {
+      "pattern1": {
+        "process_messages": [
+          "福利厚生26：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生26：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "福利厚生26：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生26：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "福利厚生26：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生26：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Wellbeing_CafeteriaPlan_027": {
+      "pattern1": {
+        "process_messages": [
+          "福利厚生27：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生27：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "福利厚生27：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生27：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "福利厚生27：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生27：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Wellbeing_HybridWork_028": {
+      "pattern1": {
+        "process_messages": [
+          "福利厚生28：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生28：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "福利厚生28：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生28：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "福利厚生28：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "福利厚生28：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Reward_NonMonetary_029": {
+      "pattern1": {
+        "process_messages": [
+          "リワード29：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リワード29：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リワード29：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リワード29：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リワード29：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リワード29：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Reward_PerformanceBased_030": {
+      "pattern1": {
+        "process_messages": [
+          "リワード30：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "リワード30：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "リワード30：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "リワード30：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "リワード30：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "リワード30：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Succession_LeaderIdentification_031": {
+      "pattern1": {
+        "process_messages": [
+          "サクセッション31：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション31：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "サクセッション31：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション31：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "サクセッション31：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション31：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Succession_DevelopmentProgram_032": {
+      "pattern1": {
+        "process_messages": [
+          "サクセッション32：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション32：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "サクセッション32：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション32：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "サクセッション32：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション32：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Succession_ProgressMonitoring_033": {
+      "pattern1": {
+        "process_messages": [
+          "サクセッション33：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション33：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "サクセッション33：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション33：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "サクセッション33：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション33：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Compliance_LaborLaw_034": {
+      "pattern1": {
+        "process_messages": [
+          "サクセッション34：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション34：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "サクセッション34：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション34：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "サクセッション34：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "サクセッション34：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Compliance_DataProtection_035": {
+      "pattern1": {
+        "process_messages": [
+          "コンプラ35：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "コンプラ35：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "コンプラ35：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "コンプラ35：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "コンプラ35：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "コンプラ35：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
+    },
+    "Compliance_InternationalRegulation_036": {
+      "pattern1": {
+        "process_messages": [
+          "コンプラ36：イベント情報の取得",
+          "Aさんの従業員情報の取得",
+          "Bさんの従業員情報の取得",
+          "Aさん向けの告知文を作成",
+          "Bさん向けの告知文を作成",
+          "Aさんに告知文章を送信",
+          "Bさんに告知文章を送信"
+        ],
+        "send_trigger_message": "コンプラ36：AさんとBさんにイベント告知をして",
+        "myle_response": "AさんとBさんにイベントを告知しました",
+        "output_url": "/images/eventNoticeResult.png"
+      },
+      "pattern2": {
+        "process_messages": [
+          "コンプラ36：女性従業員のデータを取得",
+          "女性向け産休説明会のイベント情報を取得",
+          "一人一人の従業員に対しての告知文を作成",
+          "女性従業員に告知文章を送信"
+        ],
+        "send_trigger_message": "コンプラ36：女性向け産休説明会を女性従業員に告知して",
+        "myle_response": "女性従業員に産休説明会を告知しました。",
+        "output_url": "/images/eventNoticeResult2.png"
+      },
+      "pattern3": {
+        "process_messages": [
+          "コンプラ36：管理職情報の取得",
+          "管理職向けイベント情報の取得",
+          "管理職向けの告知文を作成",
+          "管理職に告知文章を送信"
+        ],
+        "send_trigger_message": "コンプラ36：管理職に管理職向けイベントを告知して",
+        "myle_response": "管理職向けイベントを告知しました。",
+        "output_url": "/images/eventNoticeResult3.png"
+      }
     }
   }
 }

--- a/src/pages/details/Comp034Details.tsx
+++ b/src/pages/details/Comp034Details.tsx
@@ -8,7 +8,7 @@ import ResultImageContainer from "../../components/organisms/resultImageContaine
 import ChatApp from "../../components/organisms/chatContainer";
 import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
 
-const Compl034Details: React.FC = () => {
+const Comp034Details: React.FC = () => {
   const isShowOutput = useSelector(
     (state: RootState) => state.details.isShowOutput
   );
@@ -59,4 +59,4 @@ const Compl034Details: React.FC = () => {
   );
 };
 
-export default Compl034Details;
+export default Comp034Details;

--- a/src/pages/details/Comp034Details.tsx
+++ b/src/pages/details/Comp034Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Compl034Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "コンプラ34：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "コンプラ34：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "コンプラ34：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Compl034Details;

--- a/src/pages/details/Comp035Details.tsx
+++ b/src/pages/details/Comp035Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Compl035Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "コンプラ35：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "コンプラ35：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "コンプラ35：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Compl035Details;

--- a/src/pages/details/Comp035Details.tsx
+++ b/src/pages/details/Comp035Details.tsx
@@ -8,7 +8,7 @@ import ResultImageContainer from "../../components/organisms/resultImageContaine
 import ChatApp from "../../components/organisms/chatContainer";
 import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
 
-const Compl035Details: React.FC = () => {
+const Comp035Details: React.FC = () => {
   const isShowOutput = useSelector(
     (state: RootState) => state.details.isShowOutput
   );
@@ -59,4 +59,4 @@ const Compl035Details: React.FC = () => {
   );
 };
 
-export default Compl035Details;
+export default Comp035Details;

--- a/src/pages/details/Comp036Details.tsx
+++ b/src/pages/details/Comp036Details.tsx
@@ -8,7 +8,7 @@ import ResultImageContainer from "../../components/organisms/resultImageContaine
 import ChatApp from "../../components/organisms/chatContainer";
 import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
 
-const Compl036Details: React.FC = () => {
+const Comp036Details: React.FC = () => {
   const isShowOutput = useSelector(
     (state: RootState) => state.details.isShowOutput
   );
@@ -59,4 +59,4 @@ const Compl036Details: React.FC = () => {
   );
 };
 
-export default Compl036Details;
+export default Comp036Details;

--- a/src/pages/details/Comp036Details.tsx
+++ b/src/pages/details/Comp036Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Compl036Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "コンプラ36：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "コンプラ36：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "コンプラ36：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Compl036Details;

--- a/src/pages/details/Cult017Details.tsx
+++ b/src/pages/details/Cult017Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Cult017Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "組織風土17：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "組織風土17：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "組織風土17：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Cult017Details;

--- a/src/pages/details/Cult018Details.tsx
+++ b/src/pages/details/Cult018Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Cult018Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "組織風土18：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "組織風土18：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "組織風土18：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Cult018Details;

--- a/src/pages/details/Cult019Details.tsx
+++ b/src/pages/details/Cult019Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Cult019Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "組織風土19：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "組織風土19：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "組織風土19：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Cult019Details;

--- a/src/pages/details/Cult020Details.tsx
+++ b/src/pages/details/Cult020Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Cult020Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "組織風土20：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "組織風土20：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "組織風土20：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Cult020Details;

--- a/src/pages/details/Cult021Details.tsx
+++ b/src/pages/details/Cult021Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Cult021Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "組織風土21：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "組織風土21：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "組織風土21：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Cult021Details;

--- a/src/pages/details/Details.tsx
+++ b/src/pages/details/Details.tsx
@@ -6,11 +6,31 @@ import AccordionExpandIcon from "../../components/organisms/deatilNameContainer"
 import ProcessContainer from "../../components/organisms/processContainer";
 import ResultImageContainer from "../../components/organisms/resultImageContainer";
 import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
 
 const Home: React.FC = () => {
   const isShowOutput = useSelector(
     (state: RootState) => state.details.isShowOutput
   );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
 
   return (
     <Container>
@@ -30,7 +50,9 @@ const Home: React.FC = () => {
           )}
         </Grid>
         <Grid item xs={6}>
-          <ChatApp />
+          <ChatApp 
+          messageTemplates = {templates}
+          />
         </Grid>
       </Grid>
     </Container>

--- a/src/pages/details/Dive006Details.tsx
+++ b/src/pages/details/Dive006Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Dive006Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "ダイバーシティ6：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "ダイバーシティ6：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "ダイバーシティ6：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Dive006Details;

--- a/src/pages/details/Dive007Details.tsx
+++ b/src/pages/details/Dive007Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Dive007Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "ダイバーシティ7：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "ダイバーシティ7：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "ダイバーシティ7：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Dive007Details;

--- a/src/pages/details/Dive008Details.tsx
+++ b/src/pages/details/Dive008Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Dive008Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "ダイバーシティ8：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "ダイバーシティ8：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "ダイバーシティ8：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Dive008Details;

--- a/src/pages/details/Dive009Details.tsx
+++ b/src/pages/details/Dive009Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Dive009Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "ダイバーシティ9：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "ダイバーシティ9：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "ダイバーシティ9：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Dive009Details;

--- a/src/pages/details/Dive010Details.tsx
+++ b/src/pages/details/Dive010Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Dive010Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "ダイバーシティ10：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "ダイバーシティ10：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "ダイバーシティ10：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Dive010Details;

--- a/src/pages/details/Dive011Details.tsx
+++ b/src/pages/details/Dive011Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Dive011Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "ダイバーシティ11：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "ダイバーシティ11：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "ダイバーシティ11：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Dive011Details;

--- a/src/pages/details/Lead012Details.tsx
+++ b/src/pages/details/Lead012Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Lead012Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リーダーシップ12：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リーダーシップ12：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リーダーシップ12：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Lead012Details;

--- a/src/pages/details/Lead013Details.tsx
+++ b/src/pages/details/Lead013Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Lead013Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リーダーシップ13：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リーダーシップ13：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リーダーシップ13：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Lead013Details;

--- a/src/pages/details/Lead014Details.tsx
+++ b/src/pages/details/Lead014Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Lead014Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リーダーシップ14：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リーダーシップ14：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リーダーシップ14：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Lead014Details;

--- a/src/pages/details/Lead015Details.tsx
+++ b/src/pages/details/Lead015Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Lead015Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リーダーシップ15：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リーダーシップ15：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リーダーシップ15：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Lead015Details;

--- a/src/pages/details/Lead016Details.tsx
+++ b/src/pages/details/Lead016Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Lead016Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リーダーシップ16：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リーダーシップ16：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リーダーシップ16：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Lead016Details;

--- a/src/pages/details/Onb001Details.tsx
+++ b/src/pages/details/Onb001Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Onb001Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "オンボーディング1：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "オンボーディング1：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "オンボーディング1：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Onb001Details;

--- a/src/pages/details/Onb002Details.tsx
+++ b/src/pages/details/Onb002Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Onb002Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "オンボーディング2：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "オンボーディング2：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "オンボーディング2：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Onb002Details;

--- a/src/pages/details/Onb003Details.tsx
+++ b/src/pages/details/Onb003Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Onb003Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "オンボーディング3：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "オンボーディング3：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "オンボーディング3：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Onb003Details;

--- a/src/pages/details/Onb004Details.tsx
+++ b/src/pages/details/Onb004Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Onb004Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "オンボーディング4：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "オンボーディング4：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "オンボーディング4：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Onb004Details;

--- a/src/pages/details/Onb005Details.tsx
+++ b/src/pages/details/Onb005Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Onb005Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "オンボーディング5：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "オンボーディング5：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "オンボーディング5：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Onb005Details;

--- a/src/pages/details/Recr025Details.tsx
+++ b/src/pages/details/Recr025Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Recr025Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "採用関連25：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "採用関連25：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "採用関連25：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Recr025Details;

--- a/src/pages/details/Rewd029Details.tsx
+++ b/src/pages/details/Rewd029Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Rewd029Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リワード29：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リワード29：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リワード29：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Rewd029Details;

--- a/src/pages/details/Rewd030Details.tsx
+++ b/src/pages/details/Rewd030Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Rewd030Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "リワード30：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "リワード30：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "リワード30：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Rewd030Details;

--- a/src/pages/details/Skil022Details.tsx
+++ b/src/pages/details/Skil022Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Skil022Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "スキル能力22：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "スキル能力22：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "スキル能力22：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Skil022Details;

--- a/src/pages/details/Skil023Details.tsx
+++ b/src/pages/details/Skil023Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Skil023Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "スキル能力23：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "スキル能力23：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "スキル能力23：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Skil023Details;

--- a/src/pages/details/Skil024Details.tsx
+++ b/src/pages/details/Skil024Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Skil024Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "スキル能力24：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "スキル能力24：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "スキル能力24：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Skil024Details;

--- a/src/pages/details/Succ031Details.tsx
+++ b/src/pages/details/Succ031Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Succ031Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "サクセッション31：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "サクセッション31：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "サクセッション31：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Succ031Details;

--- a/src/pages/details/Succ032Details.tsx
+++ b/src/pages/details/Succ032Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Succ032Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "サクセッション32：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "サクセッション32：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "サクセッション32：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Succ032Details;

--- a/src/pages/details/Succ033Details.tsx
+++ b/src/pages/details/Succ033Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Succ033Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "サクセッション33：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "サクセッション33：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "サクセッション33：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Succ033Details;

--- a/src/pages/details/Welb026Details.tsx
+++ b/src/pages/details/Welb026Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Welb026Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "福利厚生26：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "福利厚生26：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "福利厚生26：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Welb026Details;

--- a/src/pages/details/Welb027Details.tsx
+++ b/src/pages/details/Welb027Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Welb027Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "福利厚生27：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "福利厚生27：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "福利厚生27：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Welb027Details;

--- a/src/pages/details/Welb028Details.tsx
+++ b/src/pages/details/Welb028Details.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Container, Grid } from "@mui/material";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import AccordionExpandIcon from "../../components/organisms/deatilNameContainer";
+import ProcessContainer from "../../components/organisms/processContainer";
+import ResultImageContainer from "../../components/organisms/resultImageContainer";
+import ChatApp from "../../components/organisms/chatContainer";
+import { Send as SendIcon, Help as HelpIcon, Info as InfoIcon } from "@mui/icons-material";
+
+const Welb028Details: React.FC = () => {
+  const isShowOutput = useSelector(
+    (state: RootState) => state.details.isShowOutput
+  );
+
+  // テンプレート一覧
+    const templates = [
+      {
+        messageText: "福利厚生28：AさんとBさんにイベント告知をして",
+        icon: <SendIcon fontSize="large" />,
+        type: "message",
+      },
+      {
+        messageText: "福利厚生28：女性向け産休説明会を女性従業員に告知して",
+        icon: <HelpIcon fontSize="large" />,
+        type: "help",
+      },
+      {
+        messageText: "福利厚生28：管理職に管理職向けイベントを告知して",
+        icon: <InfoIcon fontSize="large" />,
+        type: "info",
+      },
+    ];
+
+  return (
+    <Container>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sx={{ mt: 2, mb: 2 }}>
+          <AccordionExpandIcon />
+        </Grid>
+        <Grid item xs={6}>
+          <Grid item xs={12} sx={{ mb: 2 }}>
+            <ProcessContainer />
+          </Grid>
+          {/* ✅ プロセスが完了したら画像を表示 */}
+          {isShowOutput && (
+            <Grid item xs={12}>
+              <ResultImageContainer />
+            </Grid>
+          )}
+        </Grid>
+        <Grid item xs={6}>
+          <ChatApp 
+          messageTemplates = {templates}
+          />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Welb028Details;

--- a/src/pages/details/detailsSlice.ts
+++ b/src/pages/details/detailsSlice.ts
@@ -8,24 +8,26 @@ interface MessagePattern {
   output_url: string;
 }
 
+// JSONデータ読み込み
 const messagesTyped: Record<string, MessagePattern> = messagesData.messages;
 
-interface Message {
+// チャット内メッセージ情報
+interface ChatMessage {
   id: string;
-  sender: "me" | "other";
+  sender: "me" | "other"; // ユーザ側メッセージか、Myle側メッセージか
   userName: string;
-  text: string;
+  chatText: string; // メッセージ内容
 }
 
 interface ProcessMessage {
   id: string;
   state: "pending" | "processing" | "success";
   isLoading: boolean;
-  text: string;
+  processText: string;
 }
 
 interface DetailsState {
-  messages: Message[];
+  chatMessages: ChatMessage[];
   onProcessing: boolean;
   isActiveSendButton: boolean;
   processMessages: ProcessMessage[];
@@ -36,7 +38,7 @@ interface DetailsState {
 }
 
 const initialState: DetailsState = {
-  messages: [],
+  chatMessages: [],
   onProcessing: false,
   isActiveSendButton: false,
   processMessages: [],
@@ -50,8 +52,11 @@ const detailsSlice = createSlice({
   name: "details",
   initialState,
   reducers: {
+    /**
+     * 状態初期化アクション
+    */
     resetState: (state) => {
-      state.messages = [];
+      state.chatMessages = [];
       state.onProcessing = false;
       state.isActiveSendButton = false;
       state.processMessages = [];
@@ -60,24 +65,31 @@ const detailsSlice = createSlice({
       state.outputUrl = null;
       state.isShowHelpButton = true;
     },
-
-    sendMessage: (state, action: PayloadAction<Message>) => {
+    /**
+     * メッセージ送信時アクション
+    */
+    sendMessage: (state, action: PayloadAction<ChatMessage>) => {
+      // 結果が既に表示されている場合はstateをリセット
       if (state.isShowOutput) {
         detailsSlice.caseReducers.resetState(state);
       }
 
-      state.messages.push(action.payload);
+      // 入力メッセージの追加と状態の更新
+      state.chatMessages.push(action.payload);
       state.onProcessing = true;
       state.isActiveSendButton = false;
       state.isShowOutput = false;
       state.outputUrl = null; // ✅ 送信時に画像URLをリセット
 
       let selectedPattern: MessagePattern | null = null;
+
+      // 入力メッセージがテンプレパターン群と一致するか確認
       for (const pattern in messagesTyped) {
         if (
           messagesTyped[pattern as keyof typeof messagesTyped]
-            .send_trigger_message === action.payload.text
+            .send_trigger_message === action.payload.chatText
         ) {
+          // 一致するものがあれば格納
           selectedPattern =
             messagesTyped[pattern as keyof typeof messagesTyped];
           break;
@@ -85,29 +97,36 @@ const detailsSlice = createSlice({
       }
 
       if (selectedPattern) {
+        // 処理パターンがある場合
+        // 処理メッセージから各処理に関するオブジェクトを作成
         state.processMessages = selectedPattern.process_messages.map(
-          (text, index) => ({
+          (processText, index) => ({
             id: (index + 1).toString(),
             state: index === 0 ? "processing" : "pending",
             isLoading: index === 0,
-            text,
+            processText: processText,
           })
         );
         state.currentStep = 0;
         state.outputUrl = selectedPattern.output_url; // ✅ 画像URLを Redux State に保存
       } else {
-        state.messages.push({
+        // 処理パターンがない場合
+        state.chatMessages.push({
           id: new Date().getTime().toString(),
           sender: "other",
           userName: "Bot",
-          text: "対応する処理が見つかりません。",
+          chatText: "対応する処理が見つかりません。",
         });
         state.onProcessing = false;
         state.isActiveSendButton = true;
       }
     },
 
+    /**
+     * 処理を次のステップに進めるアクション
+    */
     proceedProcessing: (state) => {
+      // 現在のステップが最終ステップの場合、何もしない
       if (state.currentStep >= state.processMessages.length - 1) return;
 
       // ✅ 現在のステップを `success` にする
@@ -122,6 +141,9 @@ const detailsSlice = createSlice({
       state.currentStep = nextStep;
     },
 
+    /**
+     * 全てのステップを完全終了にするアクション
+    */
     endProcessing: (state) => {
       state.processMessages.forEach((msg) => {
         msg.state = "success";
@@ -132,15 +154,19 @@ const detailsSlice = createSlice({
       state.isShowOutput = true;
     },
 
+    /**
+     * テンプレメッセージ選択時アクション
+    */
     sendMessageByHelpButton: (state, action: PayloadAction<string>) => {
+      // sendMessageアクションを呼び出し
       detailsSlice.caseReducers.sendMessage(state, {
         payload: {
           id: new Date().getTime().toString(),
           sender: "me",
           userName: "User",
-          text: action.payload,
+          chatText: action.payload,
         },
-      } as PayloadAction<Message>);
+      } as PayloadAction<ChatMessage>);
     },
   },
 });

--- a/src/pages/details/saga.ts
+++ b/src/pages/details/saga.ts
@@ -1,5 +1,5 @@
-import { call, takeLatest, select } from "redux-saga/effects";
-import { sendMessage } from "./detailsSlice";
+import { call, takeLatest, select, put } from "redux-saga/effects";
+import { sendMessage, sendMessageByHelpButton } from "./detailsSlice";
 import axios, { AxiosResponse } from "axios";
 import { RootState } from "../../redux/store";
 
@@ -14,6 +14,7 @@ function* handleSendMessage(action: ReturnType<typeof sendMessage>) {
     const uniqueIdentifier = `${previousState.selectedMyle.elementId}_${Date.now()}`;
 
     console.log("APIリクエスト開始");
+    console.log("action.payload: ", action.payload);
     // 直接API呼び出しを行う
     const response: AxiosResponse<any> = yield call(
       axios.post,
@@ -34,9 +35,21 @@ function* handleSendMessage(action: ReturnType<typeof sendMessage>) {
   }
 }
 
+function* handleSendMessageByHelpButton(action: ReturnType<typeof sendMessageByHelpButton>) {
+  const chatText = action.payload;
+
+  // ✅ sendMessageアクションをdispatch
+  yield put(sendMessage({
+    id: new Date().getTime().toString(),
+    sender: "me",
+    userName: "User",
+    chatText,
+  }));
+}
+
 // actionを監視して適切なSagaを呼び出す
 function* watchSendMessage() {
   yield takeLatest(sendMessage.type, handleSendMessage);
+  yield takeLatest(sendMessageByHelpButton.type, handleSendMessageByHelpButton);
 }
-
 export default watchSendMessage;

--- a/src/pages/details/saga.ts
+++ b/src/pages/details/saga.ts
@@ -1,21 +1,23 @@
 import { call, takeLatest } from "redux-saga/effects";
-import { sendMessageByHelpButton } from "./detailsSlice";
+import { sendMessage } from "./detailsSlice";
 import axios, { AxiosResponse } from "axios";
 
 // APIのURL設定
 const API_URL = "https://2sva6a36r5.execute-api.ap-northeast-1.amazonaws.com";
 
 // API呼び出しを行うSaga
-function* handleSendHelpMessage(action: ReturnType<typeof sendMessageByHelpButton>) {
+function* handleSendMessage(action: ReturnType<typeof sendMessage>) {
   try {
     console.log("APIリクエスト開始");
+    console.log("action.payload", action.payload);
     // 直接API呼び出しを行う
     const response: AxiosResponse<any> = yield call(
       axios.post,
       `${API_URL}/api/v1/users/test0323/activities`, // ここをAPIGatewayのURLに設定
       {
-        elementId: action.payload, // メッセージの内容を送信
-        actionType: "selectTemplateMessage",
+        elementId: action.payload.text, // メッセージの内容を送信
+        actionType: "selectInputMessage",
+        
       }
     );
     console.log("Message saved:", response.data);
@@ -26,8 +28,8 @@ function* handleSendHelpMessage(action: ReturnType<typeof sendMessageByHelpButto
 }
 
 // actionを監視して適切なSagaを呼び出す
-function* watchHelpButton() {
-  yield takeLatest(sendMessageByHelpButton.type, handleSendHelpMessage);
+function* watchSendMessage() {
+  yield takeLatest(sendMessage.type, handleSendMessage);
 }
 
-export default watchHelpButton;
+export default watchSendMessage;

--- a/src/pages/details/saga.ts
+++ b/src/pages/details/saga.ts
@@ -3,21 +3,25 @@ import { sendMessageByHelpButton } from "./detailsSlice";
 import axios, { AxiosResponse } from "axios";
 
 // APIのURL設定
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:3000";
+const API_URL = "https://2sva6a36r5.execute-api.ap-northeast-1.amazonaws.com";
 
 // API呼び出しを行うSaga
 function* handleSendHelpMessage(action: ReturnType<typeof sendMessageByHelpButton>) {
   try {
+    console.log("APIリクエスト開始");
     // 直接API呼び出しを行う
-    const response: AxiosResponse = yield call(async (message: string) => {
-      const res = await axios.post("http://example.com/help", { message });
-      return res;
-    }, action.payload);
-
-    console.log("API呼び出し成功:", response.data);
+    const response: AxiosResponse<any> = yield call(
+      axios.post,
+      `${API_URL}/api/v1/users/test0323/activities`, // ここをAPIGatewayのURLに設定
+      {
+        elementId: action.payload, // メッセージの内容を送信
+        actionType: "selectTemplateMessage",
+      }
+    );
+    console.log("Message saved:", response.data);
     // 必要ならここでさらにReduxの状態を更新するactionをdispatch
   } catch (error) {
-    console.error("API呼び出し失敗:", error);
+    console.error("Error sending message:", error);
   }
 }
 

--- a/src/pages/details/saga.ts
+++ b/src/pages/details/saga.ts
@@ -1,0 +1,29 @@
+import { call, takeLatest } from "redux-saga/effects";
+import { sendMessageByHelpButton } from "./detailsSlice";
+import axios, { AxiosResponse } from "axios";
+
+// APIのURL設定
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:3000";
+
+// API呼び出しを行うSaga
+function* handleSendHelpMessage(action: ReturnType<typeof sendMessageByHelpButton>) {
+  try {
+    // 直接API呼び出しを行う
+    const response: AxiosResponse = yield call(async (message: string) => {
+      const res = await axios.post("http://example.com/help", { message });
+      return res;
+    }, action.payload);
+
+    console.log("API呼び出し成功:", response.data);
+    // 必要ならここでさらにReduxの状態を更新するactionをdispatch
+  } catch (error) {
+    console.error("API呼び出し失敗:", error);
+  }
+}
+
+// actionを監視して適切なSagaを呼び出す
+function* watchHelpButton() {
+  yield takeLatest(sendMessageByHelpButton.type, handleSendHelpMessage);
+}
+
+export default watchHelpButton;

--- a/src/pages/details/saga.ts
+++ b/src/pages/details/saga.ts
@@ -1,6 +1,7 @@
-import { call, takeLatest } from "redux-saga/effects";
+import { call, takeLatest, select } from "redux-saga/effects";
 import { sendMessage } from "./detailsSlice";
 import axios, { AxiosResponse } from "axios";
+import { RootState } from "../../redux/store";
 
 // APIのURL設定
 const API_URL = "https://2sva6a36r5.execute-api.ap-northeast-1.amazonaws.com";
@@ -8,16 +9,22 @@ const API_URL = "https://2sva6a36r5.execute-api.ap-northeast-1.amazonaws.com";
 // API呼び出しを行うSaga
 function* handleSendMessage(action: ReturnType<typeof sendMessage>) {
   try {
+    // ホーム画面からstateを取得
+    const previousState: RootState["home"] = yield select((state) => state.home);
+    const uniqueIdentifier = `${previousState.selectedMyle.elementId}_${Date.now()}`;
+
     console.log("APIリクエスト開始");
-    console.log("action.payload", action.payload);
     // 直接API呼び出しを行う
     const response: AxiosResponse<any> = yield call(
       axios.post,
       `${API_URL}/api/v1/users/test0323/activities`, // ここをAPIGatewayのURLに設定
       {
-        elementId: action.payload.text, // メッセージの内容を送信
-        actionType: "selectInputMessage",
-        
+        elementId: uniqueIdentifier, // メッセージの内容を送信
+        actionType: "InputMessage",
+        categoryName: previousState.selectedMyle.categoryName, // Myleのカテゴリ
+        myleId: previousState.selectedMyle.id, // カテゴリ内のMyleのID
+        myleName: previousState.selectedMyle.myleName, /// Myleの名前
+        inputText: action.payload.chatText, // ユーザが入力したテキスト
       }
     );
     console.log("Message saved:", response.data);

--- a/src/pages/home/homeSlice.ts
+++ b/src/pages/home/homeSlice.ts
@@ -1,8 +1,10 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface UserClickInfo {
+  elementId: string;
   id: string;
-  title: string;
+  categoryName: string;
+  myleName: string;
 }
 
 interface HomeState {
@@ -14,7 +16,7 @@ interface HomeState {
 const initialState: HomeState = {
   categoryA: ["Item 1", "Item 2"],
   categoryB: ["Item 3", "Item 4"],
-  selectedMyle: { id: "", title: "" },
+  selectedMyle: { elementId: "", id: "", categoryName: "", myleName: "", },
 };
 
 const homeSlice = createSlice({

--- a/src/pages/home/saga.ts
+++ b/src/pages/home/saga.ts
@@ -8,18 +8,21 @@ const API_URL = "https://2sva6a36r5.execute-api.ap-northeast-1.amazonaws.com";
 // メッセージ送信の非同期処理
 function* handleSendSelectedMyle(action: ReturnType<typeof selectMyle>) {
   try {
+    console.log("APIリクエスト開始");
+    console.log("API URL:", `${API_URL}/api/v1/users/test0323/activities`);
+    console.log("送信データ:", { elementId: action.payload.id , myleName: action.payload.title});
     // サーバーへのPOSTリクエスト
-    // /api/v1/users/{userId}/activities
     const response: AxiosResponse<any> = yield call(
       axios.post,
       `${API_URL}/api/v1/users/test0323/activities`, // ここをAPIGatewayのURLに設定
       {
-        elementId: action.payload, // メッセージの内容を送信
+        elementId: action.payload.title, // メッセージの内容を送信
+        actionType: "selectMyle",
       }
     );
 
     // リクエスト成功時の処理
-    console.log("Message saved:", response.data);
+    console.log("Selected Myle saved:", response.data);
     // TODO 必要に応じて、処理結果を別のアクションで Redux に格納する
   } catch (error) {
     // エラーハンドリング
@@ -28,8 +31,8 @@ function* handleSendSelectedMyle(action: ReturnType<typeof selectMyle>) {
 }
 
 // Sagaでactionを監視
-function* watchSendMessage() {
+function* watchSelectMyle() {
   yield takeLatest(selectMyle.type, handleSendSelectedMyle);
 }
 
-export default watchSendMessage;
+export default watchSelectMyle;

--- a/src/pages/home/saga.ts
+++ b/src/pages/home/saga.ts
@@ -2,21 +2,25 @@ import { call, takeLatest } from "redux-saga/effects";
 import { selectMyle } from "./homeSlice";
 import axios, { AxiosResponse } from "axios";
 
+// APIのURL設定
+const API_URL = "https://2sva6a36r5.execute-api.ap-northeast-1.amazonaws.com";
+
 // メッセージ送信の非同期処理
 function* handleSendSelectedMyle(action: ReturnType<typeof selectMyle>) {
   try {
     // サーバーへのPOSTリクエスト
+    // /api/v1/users/{userId}/activities
     const response: AxiosResponse<any> = yield call(
       axios.post,
-      "http://aaa.com/save", // ここをAPIGatewayのURLに設定
+      `${API_URL}/api/v1/users/test0323/activities`, // ここをAPIGatewayのURLに設定
       {
-        data: action.payload, // メッセージの内容を送信
+        elementId: action.payload, // メッセージの内容を送信
       }
     );
 
     // リクエスト成功時の処理
     console.log("Message saved:", response.data);
-    // 必要に応じて、処理結果を別のアクションで Redux に格納する
+    // TODO 必要に応じて、処理結果を別のアクションで Redux に格納する
   } catch (error) {
     // エラーハンドリング
     console.error("Error sending message:", error);

--- a/src/pages/home/saga.ts
+++ b/src/pages/home/saga.ts
@@ -10,14 +10,17 @@ function* handleSendSelectedMyle(action: ReturnType<typeof selectMyle>) {
   try {
     console.log("APIリクエスト開始");
     console.log("API URL:", `${API_URL}/api/v1/users/test0323/activities`);
-    console.log("送信データ:", { elementId: action.payload.id , myleName: action.payload.title});
+    console.log("送信データ:", { payload: action.payload });
     // サーバーへのPOSTリクエスト
     const response: AxiosResponse<any> = yield call(
       axios.post,
       `${API_URL}/api/v1/users/test0323/activities`, // ここをAPIGatewayのURLに設定
       {
-        elementId: action.payload.title, // メッセージの内容を送信
-        actionType: "selectMyle",
+        elementId: action.payload.elementId, // 操作データを識別する一意な文字列
+        actionType: "selectMyle", // 操作種別：Myle選択
+        categoryName: action.payload.categoryName, // Myleのカテゴリ
+        myleId: action.payload.id, // カテゴリ内のMyleのID
+        myleName: action.payload.myleName, /// Myleの名前
       }
     );
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -3,7 +3,7 @@ import homeReducer from "../pages/home/homeSlice";
 import detailsReducer from "../pages/details/detailsSlice";
 import createSagaMiddleware from "redux-saga";
 import watchSelectMyle from "../pages/home/saga";
-import watchHelpButton from "../pages/details/saga";
+import watchSendMessage from "../pages/details/saga";
 
 const sagaMiddleware = createSagaMiddleware();
 
@@ -17,7 +17,7 @@ const store = configureStore({
 });
 
 sagaMiddleware.run(watchSelectMyle);
-sagaMiddleware.run(watchHelpButton);
+sagaMiddleware.run(watchSendMessage);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -2,7 +2,8 @@ import { configureStore } from "@reduxjs/toolkit";
 import homeReducer from "../pages/home/homeSlice";
 import detailsReducer from "../pages/details/detailsSlice";
 import createSagaMiddleware from "redux-saga";
-import watchSendMessage from "../pages/home/saga";
+import watchSelectMyle from "../pages/home/saga";
+import watchHelpButton from "../pages/details/saga";
 
 const sagaMiddleware = createSagaMiddleware();
 
@@ -15,7 +16,8 @@ const store = configureStore({
     getDefaultMiddleware().concat(sagaMiddleware),
 });
 
-sagaMiddleware.run(watchSendMessage);
+sagaMiddleware.run(watchSelectMyle);
+sagaMiddleware.run(watchHelpButton);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
実装処理：
1. DB登録処理を追加
・ホーム画面でのMyle選択データをDBに投入
・詳細画面でのテンプレ選択データをDBに投入
・詳細画面での自由入力データをDBに投入
2. 詳細画面をMyleごとに作成、テンプレメッセージと処理トレースを出しわけ

残：
1. 各画面のテンプレメッセージと処理トレースの内容を考えて反映する
2. ホームと詳細を行ったり来たりすると前の詳細画面でのメッセージがチャット内に残ってしまうバグの改修
3. ホーム画面でのMyleの画像をそれぞれどれにするか決めて反映